### PR TITLE
Add movie model and home screen with example movies

### DIFF
--- a/lib/component/movie_card.dart
+++ b/lib/component/movie_card.dart
@@ -1,0 +1,20 @@
+import 'package:filmes_com_api/model/movie.dart';
+import 'package:flutter/material.dart';
+
+class MovieCard extends StatelessWidget {
+  const MovieCard({
+    super.key,
+    required this.movie,
+  });
+
+  final Movie movie;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(movie.title),
+      subtitle: Text(movie.director),
+      trailing: Text(movie.year.toString()),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:filmes_com_api/screen/home_screen.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -13,113 +14,10 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/model/movie.dart
+++ b/lib/model/movie.dart
@@ -1,0 +1,16 @@
+class Movie {
+  final String title;
+  final String director;
+  final int year;
+  String? poster;
+  String? plot;
+
+  Movie({required this.title,
+    required this.director,
+    required this.year});
+
+  @override
+  String toString() {
+    return 'Movie{title: $title, director: $director, year: $year, poster: $poster, plot: $plot}';
+  }
+}

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -1,0 +1,44 @@
+import 'package:filmes_com_api/model/movie.dart';
+import 'package:filmes_com_api/component/movie_card.dart';
+import 'package:flutter/material.dart';
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key, required this.title});
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+
+  var exampleMovies = [
+    Movie(title: "O sexto sentido", director: "M. Night S.", year: 1999),
+    Movie(title: "Matrix", director: "Lana Wachowski, Lilly Wachowski", year: 1999),
+    Movie(title: "Clube da Luta", director: "David Fincher", year: 1999),
+    Movie(title: "Forrest Gump", director: "Robert Zemeckis", year: 1994),
+    Movie(title: "O Poderoso Chefão", director: "Francis Ford Coppola", year: 1972),
+    Movie(title: "Pulp Fiction", director: "Quentin Tarantino", year: 1994),
+    Movie(title: "A Origem", director: "Christopher Nolan", year: 2010),
+    Movie(title: "Interestelar", director: "Christopher Nolan", year: 2014),
+    Movie(title: "O Senhor dos Anéis: A Sociedade do Anel", director: "Peter Jackson", year: 2001),
+    Movie(title: "Star Wars: Episódio IV - Uma Nova Esperança", director: "George Lucas", year: 1977)
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: ListView.builder(
+            itemCount: exampleMovies.length,
+            itemBuilder: (context, index) {
+              return MovieCard(movie: exampleMovies[index]);
+            })
+      ),
+      );
+  }
+}


### PR DESCRIPTION
Created a `Movie` class to represent movie data, including title, director, and year, with optional poster and plot. Introduced a `HomeScreen` that displays a list of example movies using the `MovieCard` widget. Cleaned up the `main.dart` file by moving home screen logic into a dedicated file.